### PR TITLE
Bugfix #692 cancel freeze

### DIFF
--- a/Assets/PatchKit Patcher/Scripts/AppData/Remote/Downloaders/HttpDownloader.cs
+++ b/Assets/PatchKit Patcher/Scripts/AppData/Remote/Downloaders/HttpDownloader.cs
@@ -145,14 +145,14 @@ namespace PatchKit.Unity.Patcher.AppData.Remote.Downloaders
                     }
                 }
 
-                
-                DebugLogger.Log("Waiting 10 seconds before trying again...");
                 int retrySleepDuration = 10000;
+                int singleSleep = 100;
+                DebugLogger.LogFormat("Waiting {0} seconds before trying again...", retrySleepDuration/1000);
                 // FIX: Bug #692
-                for (int i = 0; i < retrySleepDuration; ++i)
+                for (int i = 0; i < retrySleepDuration/singleSleep; ++i)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    Thread.Sleep(1);
+                    Thread.Sleep(singleSleep);
                 }
             }
 

--- a/Assets/PatchKit Patcher/Scripts/AppData/Remote/Downloaders/HttpDownloader.cs
+++ b/Assets/PatchKit Patcher/Scripts/AppData/Remote/Downloaders/HttpDownloader.cs
@@ -145,8 +145,15 @@ namespace PatchKit.Unity.Patcher.AppData.Remote.Downloaders
                     }
                 }
 
+                
                 DebugLogger.Log("Waiting 10 seconds before trying again...");
-                Thread.Sleep(10000);
+                int retrySleepDuration = 10000;
+                // FIX: Bug #692
+                for (int i = 0; i < retrySleepDuration; ++i)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Thread.Sleep(1);
+                }
             }
 
             if (retry <= 0)

--- a/Assets/PatchKit Patcher/Scripts/AppData/Remote/Downloaders/HttpDownloader.cs
+++ b/Assets/PatchKit Patcher/Scripts/AppData/Remote/Downloaders/HttpDownloader.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using PatchKit.Unity.Patcher.Cancellation;
 using PatchKit.Unity.Patcher.Debug;
+using PatchKit.Unity.Utilities;
 
 namespace PatchKit.Unity.Patcher.AppData.Remote.Downloaders
 {
@@ -145,15 +146,8 @@ namespace PatchKit.Unity.Patcher.AppData.Remote.Downloaders
                     }
                 }
 
-                int retrySleepDuration = 10000;
-                int singleSleep = 100;
-                DebugLogger.LogFormat("Waiting {0} seconds before trying again...", retrySleepDuration/1000);
-                // FIX: Bug #692
-                for (int i = 0; i < retrySleepDuration/singleSleep; ++i)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    Thread.Sleep(singleSleep);
-                }
+                DebugLogger.Log("Waiting 10 seconds before trying again...");
+                Threading.CancelableSleep(10000, cancellationToken);
             }
 
             if (retry <= 0)

--- a/Assets/PatchKit Patcher/Scripts/Utilities/Threading.cs
+++ b/Assets/PatchKit Patcher/Scripts/Utilities/Threading.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Threading;
+using PatchKit.Unity.Patcher.Cancellation;
 using UnityEngine;
 
 namespace PatchKit.Unity.Utilities
@@ -61,6 +62,22 @@ namespace PatchKit.Unity.Utilities
             finally
             {
                 thread.Abort();
+            }
+        }
+
+        /// <summary>
+        /// Like Thread.Sleep() but checks if cancelation occured meanwhile 
+        /// </summary>
+        /// <param name="duration">Miliseconds, time to sleep</param>
+        /// <param name="cancellationToken">token to check cancellation exception</param>
+        public static void CancelableSleep(int duration, CancellationToken cancellationToken)
+        {
+            // FIX: Bug #692
+            int singleSleep = 100;
+            for (int i = 0; i < duration / singleSleep; ++i)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Thread.Sleep(singleSleep);
             }
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - Fallback for content strategy in case of diff strategy failure
-- Fixed error when Patcher would appear to be unresponding during downloading
 
 ### Changed
 - Geolocate: Increased timeout from 5s to 10s
@@ -15,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Compilation error on Unity 5.6 or higher
 - Geolocate: NullReferenceException on timeout
+- Error when Patcher would appear to be unresponding during downloading
 
 ## [3.4.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - Fallback for content strategy in case of diff strategy failure
+- Fixed error when Patcher would appear to be unresponding during downloading
 
 ### Changed
 - Geolocate: Increased timeout from 5s to 10s


### PR DESCRIPTION
All editor tests passed.
development platform: Windows.

Plenty of alternatives to Thread.Sleep(), to be considered in further design and Mono Framework change
https://stackoverflow.com/questions/5424667/alternatives-to-thread-sleep