### PR TITLE
Bugfix #722: handle HttpWebRequestAdapter.GetResponse() exceptions

### DIFF
--- a/Assets/PatchKit Patcher/Scripts/AppData/Remote/RemoteResourceDownloader.cs
+++ b/Assets/PatchKit Patcher/Scripts/AppData/Remote/RemoteResourceDownloader.cs
@@ -17,7 +17,7 @@ namespace PatchKit.Unity.Patcher.AppData.Remote
         private const int TorrentDownloaderTimeout = 10000;
         private const int ChunkedHttpDownloaderTimeout = 30000;
         private const int HttpDownloaderTimeout = 30000;
-        private const int RetriesCount = 8;
+        private const int RetriesCount = 8; // FIX: #722
         private readonly string _destinationFilePath;
         private readonly string _destinationMetaPath;
 
@@ -132,7 +132,6 @@ namespace PatchKit.Unity.Patcher.AppData.Remote
             {
                 try
                 {
-                    DebugLogger.LogWarningFormat("Resolving Dowloader: try {0}/8", RetriesCount-retriesLeft+1);
                     ResolveDownloader(cancellationToken);
                 }
                 catch (Exception ex)
@@ -140,11 +139,11 @@ namespace PatchKit.Unity.Patcher.AppData.Remote
                     if (retriesLeft > 0)
                     {
                         retriesLeft--;
-                        DebugLogger.LogWarningFormat("Resolving Dowloader failed, retry: {0}/8", RetriesCount-retriesLeft+1);
+                        DebugLogger.LogWarningFormat("Resolving Dowloader failed, retry: {0}/{1}", RetriesCount-retriesLeft+1, RetriesCount);
                     }
                     else
                     {
-                        DebugLogger.LogWarningFormat("Resolving Dowloader failed, no retries left, throwing further");
+                        DebugLogger.LogErrorFormat("Resolving Dowloader failed, no retries left, throwing further");
                         throw ex;
                     }
                 }

--- a/Assets/PatchKit Patcher/Scripts/AppData/Remote/RemoteResourceDownloader.cs
+++ b/Assets/PatchKit Patcher/Scripts/AppData/Remote/RemoteResourceDownloader.cs
@@ -128,6 +128,8 @@ namespace PatchKit.Unity.Patcher.AppData.Remote
 
         public void Download(CancellationToken cancellationToken)
         {
+            Assert.MethodCalledOnlyOnce(ref _downloadHasBeenCalled, "Download");
+
             int retriesLeft = RetriesCount;
             do
             {
@@ -160,8 +162,6 @@ namespace PatchKit.Unity.Patcher.AppData.Remote
 
         private void ResolveDownloader(CancellationToken cancellationToken)
         {
-            Assert.MethodCalledOnlyOnce(ref _downloadHasBeenCalled, "Download");
-
             if (_resource.HasMetaUrls())
             {
                 DebugLogger.Log("Downloading meta data...");

--- a/Assets/PatchKit Patcher/Scripts/AppData/Remote/RemoteResourceDownloader.cs
+++ b/Assets/PatchKit Patcher/Scripts/AppData/Remote/RemoteResourceDownloader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using PatchKit.Unity.Patcher.AppData.Remote.Downloaders;
 using PatchKit.Unity.Patcher.Cancellation;
 using PatchKit.Unity.Patcher.Debug;
@@ -133,9 +134,16 @@ namespace PatchKit.Unity.Patcher.AppData.Remote
                 try
                 {
                     ResolveDownloader(cancellationToken);
-                }
+                }                
                 catch (Exception ex)
                 {
+                    if (ex is OperationCanceledException ||
+                        ex is UnauthorizedAccessException ||
+                        ex is ThreadAbortException)
+                    {
+                        throw ex;
+                    }
+
                     if (retriesLeft > 0)
                     {
                         retriesLeft--;
@@ -146,7 +154,7 @@ namespace PatchKit.Unity.Patcher.AppData.Remote
                         DebugLogger.LogErrorFormat("Resolving Dowloader failed, no retries left, throwing further");
                         throw ex;
                     }
-                }
+                }  
             } while (retriesLeft > 0);
         }
 


### PR DESCRIPTION
Note:
Investigated according to stack trace supplied from task description, I do not have access to sentry yet.